### PR TITLE
Add ActiveModel::CompositeCommand

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,6 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     minitest (5.14.1)
-    rake (10.5.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -45,8 +44,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_command!
   bundler (~> 2.0)
-  rake (~> 10.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/active_model/command.rb
+++ b/lib/active_model/command.rb
@@ -72,6 +72,5 @@ module ActiveModel
     def called?
       @called ||= false
     end
-
   end
 end

--- a/lib/active_model/composite_command.rb
+++ b/lib/active_model/composite_command.rb
@@ -1,0 +1,35 @@
+module ActiveModel
+  module CompositeCommand
+    class HaltedExecution < RuntimeError
+      attr_reader :command
+
+      def initialize(command)
+        @command = command
+      end
+    end
+
+    def self.prepended(base)
+      base.prepend ActiveModel::Command
+    end
+
+    def call
+      super
+    rescue HaltedExecution => error
+      handle_halted_execution(error)
+    end
+
+    private
+
+    def handle_halted_execution(error)
+      @errors.merge!(error.command.errors)
+      @result = nil
+    end
+
+    def call_subcommand(command)
+      raise ArgumentError, "not a command" unless command.is_a?(Command)
+      command.call unless command.send(:called?)
+      return command.result if command.success?
+      raise HaltedExecution.new(command)
+    end
+  end
+end

--- a/lib/active_model_command.rb
+++ b/lib/active_model_command.rb
@@ -1,1 +1,2 @@
 require "active_model/command"
+require "active_model/composite_command"

--- a/spec/active_model/composite_command_spec.rb
+++ b/spec/active_model/composite_command_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe ActiveModel::CompositeCommand do
+  def success_command
+    TestCommand.new(:success)
+  end
+
+  def failure_command
+    TestCommand.new(:failure)
+  end
+
+  def exception_command
+    TestCommand.new(:raise)
+  end
+
+  subject(:command) { CompositeCommand.new(subcommands) }
+  let(:errors) { command.errors }
+
+  describe "#call" do
+    context "when all subcommands are a success" do
+      before do
+        command.call
+      end
+
+      let(:command) { CompositeCommand.new([success_command])}
+
+      it { is_expected.to be_success }
+
+      it "has a result" do
+        expect(command.result).to eq(:result)
+      end
+    end
+
+    context "when a subcommand fails" do
+      before do
+        command.call
+      end
+
+      let(:command) { CompositeCommand.new([failure_command])}
+
+      it { is_expected.to be_failure }
+
+      it "adds errors" do
+        expect(errors[:base]).to include(/failure/)
+      end
+
+      it "does not have a result" do
+        expect(command.result).to be_nil
+      end
+    end
+
+    context "when a subcommand raises an exception" do
+      let(:command) { CompositeCommand.new([exception_command])}
+
+      it "bubbles the exception up to the caller" do
+        expect { command.call }.to raise_error(RuntimeError)
+      end
+
+      it "does not have a result" do
+        command.call
+      rescue RuntimeError
+        expect(command.result).to be_nil
+      end
+    end
+
+    context "when a subcommand is a composite" do
+      let(:command) { CompositeCommand.new([composite]) }
+
+      context "which is a success" do
+        let(:composite) { CompositeCommand.new([success_command]) }
+
+        before do
+          command.call
+        end
+
+        let(:subcommands) { [success_composite] }
+
+        it { is_expected.to be_success }
+
+        it "has a result" do
+          expect(command.result).to eq(:result)
+        end
+      end
+
+      context "which is a failure" do
+        before do
+          command.call
+        end
+
+        let(:composite) { CompositeCommand.new([failure_command]) }
+
+        it "adds errors" do
+          expect(errors[:base]).to include(/failure/)
+        end
+
+        it "does not have a result" do
+          expect(command.result).to be_nil
+        end
+      end
+
+      context "which raises" do
+        let(:composite) { CompositeCommand.new([exception_command]) }
+
+        it "bubbles the exception up to the caller" do
+          expect { command.call }.to raise_error(RuntimeError)
+        end
+
+        it "does not have a result" do
+          command.call
+        rescue RuntimeError
+          expect(command.result).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/examples/composite_command.rb
+++ b/spec/examples/composite_command.rb
@@ -1,0 +1,18 @@
+class CompositeCommand
+  prepend ActiveModel::CompositeCommand
+  attr_reader :subcommands
+
+  validates :subcommands, presence: true
+
+  def initialize(subcommands)
+    @subcommands = subcommands
+  end
+
+  def call
+    subcommands.each do |subcommand|
+      call_subcommand subcommand
+    end
+
+    :result
+  end
+end

--- a/spec/examples/test_command.rb
+++ b/spec/examples/test_command.rb
@@ -1,0 +1,18 @@
+class TestCommand
+  prepend ActiveModel::Command
+
+  def initialize(on_call)
+    @on_call = on_call
+  end
+
+  def call
+    case @on_call
+    when :raise
+      raise RuntimeError
+    when :success
+      return :success
+    else :failure
+      errors.add(:base, :failure)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "active_model/command"
+require "active_model/composite_command"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Adds composite commands which may be used to combine multiple smaller
subcommands. Subcommands may be other composite commands. When a
subcommand fails, it halts execution and returns a failure.