### PR TITLE
call super without args

### DIFF
--- a/lib/active_model/command.rb
+++ b/lib/active_model/command.rb
@@ -9,8 +9,8 @@ module ActiveModel
     attr_reader :result
 
     module ClassMethods
-      def call(*args, **kwargs)
-        new(*args, **kwargs).call
+      def call(*args)
+        new(*args).call
       end
     end
 
@@ -19,8 +19,8 @@ module ActiveModel
       base.send(:include, ActiveModel::Model)
     end
 
-    def initialize(*args, **kwargs)
-      super(*args, **kwargs) # Either defined in class or passed up to ActiveModel::Model
+    def initialize(*)
+      super
       after_initialize
     end
 


### PR DESCRIPTION
Calling `super` without arguments is what we want here. The `**kwargs` is causing objects which can be converted to a hash to be converted and passed as keyword arguments.