### PR TITLE
Include ActiveModel::Validations::Callbacks when prepended

### DIFF
--- a/lib/active_model/command.rb
+++ b/lib/active_model/command.rb
@@ -17,6 +17,7 @@ module ActiveModel
     def self.prepended(base)
       base.extend ClassMethods
       base.send(:include, ActiveModel::Model)
+      base.send(:include, ActiveModel::Validations::Callbacks)
     end
 
     def initialize(*args, **kwargs)

--- a/spec/active_model/command_spec.rb
+++ b/spec/active_model/command_spec.rb
@@ -117,6 +117,23 @@ RSpec.describe ActiveModel::Command do
       end
     end
 
+    context "with callbacks" do
+      let(:command){ CallbackCommand.new }
+
+      it "does call #call" do # and call only calles execute_command
+        expect(command).to receive(:execute_command)
+        command.call
+      end
+
+      it "does set the result" do
+        expect{ command.call }.to change{ command.result }.to("example")
+      end
+
+      it "doesn't have errors" do
+        expect(command.call.errors).to be_empty
+      end
+    end
+
     context "when command has noop? that returns true" do
       before do
         allow(command).to receive(:noop?).and_return(true)

--- a/spec/examples/callback_command.rb
+++ b/spec/examples/callback_command.rb
@@ -1,0 +1,21 @@
+class CallbackCommand
+  prepend ActiveModel::Command
+
+  attr_reader :say
+
+  before_validation :set_message
+
+  def call
+    execute_command
+  end
+
+  private
+
+  def execute_command
+    say
+  end
+
+  def set_message
+    @say = "example"
+  end
+end


### PR DESCRIPTION
We started using callbacks in a couple of commands in https://github.com/goldstar/stellar/. We're adding them to the command so they're already available when needed.