### PR TITLE
Add #given? helper method

### DIFF
--- a/lib/active_model/command.rb
+++ b/lib/active_model/command.rb
@@ -68,6 +68,13 @@ module ActiveModel
       return super if defined?(super)
     end
 
+    protected
+
+    def given?(attribute_name)
+      respond_to?(attribute_name) &&
+      instance_variable_defined?("@#{attribute_name}")
+    end
+
     private
 
     def called?

--- a/spec/active_model/command_spec.rb
+++ b/spec/active_model/command_spec.rb
@@ -178,6 +178,16 @@ RSpec.describe ActiveModel::Command do
         expect{ command.call }.to raise_error(ActiveModel::Command::AlreadyExecuted)
       end
     end
+
+    context "with behavior only when given attribute" do
+      let(:with_given_attribute) { GivenCommand.call(name: "foo") }
+      let(:without_given_attribute) { GivenCommand.call }
+
+      it "can check if attribute was given", :aggregate_failures do
+        expect(with_given_attribute.result).to eq "foo"
+        expect(without_given_attribute.result).to eq nil
+      end
+    end
   end
 
   describe '.call' do

--- a/spec/examples/given_command.rb
+++ b/spec/examples/given_command.rb
@@ -1,0 +1,9 @@
+class GivenCommand
+  prepend ActiveModel::Command
+
+  attr_accessor :name
+
+  def call
+    name if given?(:name)
+  end
+end


### PR DESCRIPTION
Adds method to check if an attribute was given to the command. This is useful for commands that only update an object's attribute if a new value was given for that attribute.