### PR TITLE
Add subject macro and #changed? helper method

### DIFF
--- a/lib/active_model/command.rb
+++ b/lib/active_model/command.rb
@@ -4,7 +4,7 @@ require "active_model/command/version"
 module ActiveModel
   module Command
     AlreadyExecuted = Class.new(RuntimeError)
-    UndefinedAggregateError = Class.new(StandardError)
+    UndefinedSubjectError = Class.new(StandardError)
     UnsupportedErrors = Class.new(RuntimeError)
 
     attr_reader :result
@@ -14,10 +14,10 @@ module ActiveModel
         new(*args, **kwargs).call
       end
 
-      attr_accessor :aggregate_name
+      attr_accessor :subject_name
 
-      def aggregate(value)
-        self.aggregate_name = value
+      def subject(value)
+        self.subject_name = value
         attr_accessor value
       end
     end
@@ -76,25 +76,25 @@ module ActiveModel
       return super if defined?(super)
     end
 
-    def aggregate
-      return @aggregate if defined? @aggregate
+    def subject
+      return @subject if defined? @subject
 
-      if self.class.aggregate_name.nil?
-        fail UndefinedAggregateError,
-          "Define aggregate name with .aggregate macro"
+      if self.class.subject_name.nil?
+        fail UndefinedSubjectError,
+          "Define subject name with .subject macro"
       end
 
-      @aggregate = send(self.class.aggregate_name)
+      @subject = send(self.class.subject_name)
     end
 
     protected
 
     def changed?(attribute_name, strict=false)
       return false unless given?(attribute_name)
-      return false unless aggregate.present?
-      return false unless aggregate.respond_to?(attribute_name)
+      return false unless subject.present?
+      return false unless subject.respond_to?(attribute_name)
 
-      original_value = aggregate.public_send(attribute_name)
+      original_value = subject.public_send(attribute_name)
       given_value = send(attribute_name)
 
       if given_value.kind_of?(Array) && !strict

--- a/spec/active_model/command_spec.rb
+++ b/spec/active_model/command_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe ActiveModel::Command do
       end
     end
 
-    context "with behavior only when given changed attribute for aggregate" do
+    context "with behavior only when given changed attribute for subject" do
       let(:user) {
         ChangedCommand::User.new(
           name: "foo",
@@ -272,43 +272,43 @@ RSpec.describe ActiveModel::Command do
     end
   end
 
-  describe ".aggregate macro" do
+  describe ".subject macro" do
     let(:klass) {
       Class.new do
         prepend ActiveModel::Command
-        aggregate :foo
+        subject :foo
       end
     }
     let(:instance) { klass.new }
 
-    it "assigns .aggregate_name" do
-      expect(klass.aggregate_name).to eq :foo
+    it "assigns .subject_name" do
+      expect(klass.subject_name).to eq :foo
     end
 
-    it "adds accessor for aggregate" do
+    it "adds accessor for subject" do
       expect(instance).
         to respond_to(:foo).
         and respond_to(:foo=)
     end
   end
 
-  describe "#aggregate" do
+  describe "#subject" do
     let(:instance) { klass.new(foo: "bar") }
 
-    subject(:aggregate) { instance.aggregate }
+    subject { instance.subject }
 
-    context "with aggregate defined by macro" do
+    context "with subject defined by macro" do
       let(:klass) {
         Class.new do
           prepend ActiveModel::Command
-          aggregate :foo
+          subject :foo
         end
       }
 
       it { is_expected.to eq "bar" }
     end
 
-    context "without aggregate defined by macro" do
+    context "without subject defined by macro" do
       let(:klass) {
         Class.new do
           prepend ActiveModel::Command
@@ -317,7 +317,7 @@ RSpec.describe ActiveModel::Command do
       }
 
       it "fails with exception" do
-        expect { aggregate }.to raise_error(described_class::UndefinedAggregateError)
+        expect { subject }.to raise_error(described_class::UndefinedSubjectError)
       end
     end
   end

--- a/spec/active_model/command_spec.rb
+++ b/spec/active_model/command_spec.rb
@@ -188,9 +188,77 @@ RSpec.describe ActiveModel::Command do
         expect(without_given_attribute.result).to eq nil
       end
     end
+
+    context "with behavior only when given changed attribute for aggregate" do
+      let(:user) {
+        ChangedCommand::User.new(
+          name: "foo",
+          sorted_tags: ["a", "b"],
+          unsorted_tags: ["a", "b"]
+        )
+      }
+      let(:with_changed_attribute) { ChangedCommand.call(user: user, name: "bar") }
+      let(:with_unchanged_attribute) { ChangedCommand.call(user: user, name: user.name) }
+      let(:without_given_attribute) { ChangedCommand.call(user: user) }
+
+      it "can check if attribute was changed", :aggregate_failures do
+        expect(with_changed_attribute).to be_success
+        expect(with_changed_attribute.result).to include :name_changed
+
+        expect(with_unchanged_attribute).to be_success
+        expect(with_unchanged_attribute.result).to_not include :name_changed
+
+        expect(without_given_attribute).to be_success
+        expect(without_given_attribute.result).to_not include :name_changed
+      end
+
+      context "when attribute is an array" do
+        context "and order matters" do
+          let(:with_appended_attribute) { ChangedCommand.call(user: user, sorted_tags: ["a", "b", "c"]) }
+          let(:with_reduced_attribute) { ChangedCommand.call(user: user, sorted_tags: ["a"]) }
+          let(:with_reordered_attribute) { ChangedCommand.call(user: user, sorted_tags: user.sorted_tags.reverse) }
+          let(:with_unchanged_attribute) { ChangedCommand.call(user: user, sorted_tags: user.sorted_tags) }
+
+          it "can check if attribute was changed including order" do
+            expect(with_appended_attribute).to be_success
+            expect(with_appended_attribute.result).to include :sorted_tags_changed
+
+            expect(with_reduced_attribute).to be_success
+            expect(with_reduced_attribute.result).to include :sorted_tags_changed
+
+            expect(with_reordered_attribute).to be_success
+            expect(with_reordered_attribute.result).to include :sorted_tags_changed
+
+            expect(with_unchanged_attribute).to be_success
+            expect(with_unchanged_attribute.result).to_not include :sorted_tags_changed
+          end
+        end
+
+        context "and order doesn't matter" do
+          let(:with_appended_attribute) { ChangedCommand.call(user: user, unsorted_tags: ["a", "b", "c"]) }
+          let(:with_reduced_attribute) { ChangedCommand.call(user: user, unsorted_tags: ["a"]) }
+          let(:with_reordered_attribute) { ChangedCommand.call(user: user, unsorted_tags: user.unsorted_tags.reverse) }
+          let(:with_unchanged_attribute) { ChangedCommand.call(user: user, unsorted_tags: user.unsorted_tags) }
+
+          it "can check if attribute was changed regardless of order" do
+            expect(with_appended_attribute).to be_success
+            expect(with_appended_attribute.result).to include :unsorted_tags_changed
+
+            expect(with_reduced_attribute).to be_success
+            expect(with_reduced_attribute.result).to include :unsorted_tags_changed
+
+            expect(with_reordered_attribute).to be_success
+            expect(with_reordered_attribute.result).to_not include :unsorted_tags_changed
+
+            expect(with_unchanged_attribute).to be_success
+            expect(with_unchanged_attribute.result).to_not include :unsorted_tags_changed
+          end
+        end
+      end
+    end
   end
 
-  describe '.call' do
+  describe ".call" do
     before do
       allow(SuccessfulCommand).to receive(:new).and_return(command)
       allow(command).to receive(:call)
@@ -204,4 +272,53 @@ RSpec.describe ActiveModel::Command do
     end
   end
 
+  describe ".aggregate macro" do
+    let(:klass) {
+      Class.new do
+        prepend ActiveModel::Command
+        aggregate :foo
+      end
+    }
+    let(:instance) { klass.new }
+
+    it "assigns .aggregate_name" do
+      expect(klass.aggregate_name).to eq :foo
+    end
+
+    it "adds accessor for aggregate" do
+      expect(instance).
+        to respond_to(:foo).
+        and respond_to(:foo=)
+    end
+  end
+
+  describe "#aggregate" do
+    let(:instance) { klass.new(foo: "bar") }
+
+    subject(:aggregate) { instance.aggregate }
+
+    context "with aggregate defined by macro" do
+      let(:klass) {
+        Class.new do
+          prepend ActiveModel::Command
+          aggregate :foo
+        end
+      }
+
+      it { is_expected.to eq "bar" }
+    end
+
+    context "without aggregate defined by macro" do
+      let(:klass) {
+        Class.new do
+          prepend ActiveModel::Command
+          attr_accessor :foo
+        end
+      }
+
+      it "fails with exception" do
+        expect { aggregate }.to raise_error(described_class::UndefinedAggregateError)
+      end
+    end
+  end
 end

--- a/spec/examples/changed_command.rb
+++ b/spec/examples/changed_command.rb
@@ -7,7 +7,7 @@ class ChangedCommand
     attr_accessor :name, :sorted_tags, :unsorted_tags
   end
 
-  aggregate :user
+  subject :user
 
   attr_accessor :name, :sorted_tags, :unsorted_tags
 

--- a/spec/examples/changed_command.rb
+++ b/spec/examples/changed_command.rb
@@ -1,0 +1,41 @@
+class ChangedCommand
+  prepend ActiveModel::Command
+
+  class User
+    include ActiveModel::Model
+
+    attr_accessor :name, :sorted_tags, :unsorted_tags
+  end
+
+  aggregate :user
+
+  attr_accessor :name, :sorted_tags, :unsorted_tags
+
+  def call
+    check_name
+    check_sorted_tags
+    check_unsorted_tags
+    results
+  end
+
+  private
+
+  def results
+    @results ||= []
+  end
+
+  def check_name
+    return unless changed?(:name)
+    results << :name_changed
+  end
+
+  def check_sorted_tags
+    return unless changed?(:sorted_tags, true)
+    results << :sorted_tags_changed
+  end
+
+  def check_unsorted_tags
+    return unless changed?(:unsorted_tags, false)
+    results << :unsorted_tags_changed
+  end
+end


### PR DESCRIPTION
Adds `.subject` macro to define which attribute is the subject
that the command is acting on. Calling the macro defines the subject
name and adds an attr_accessor.

```
class UserCommand
  prepend ActiveModel::Command

  subject :user
end
```

Adds `#subject` instance method which returns the subject if it has
been defined with the macro.

Adds `#changed?` helper method which checks if an attribute was given
and is different from the subject's value for that attribute. This
method is dependent on the subject having been defined with the macro.

```
class UserCommand
  prepend ActiveModel::Command

  subject :user

  attr_accessor :name

  def call
    if changed?(:name)
      user.name = name
    end
    user
  end
end
```

For array attributes, it is assumed that order does not matter. In cases
where order does matter, `true` can be passed as a second argument to
compare them strictly.

```
class UserCommand
  prepend ActiveModel::Command

  subject :user

  attr_accessor :sorted_tags

  def call
    if changed?(:sorted_tags, true)
      user.sorted_tags = sorted_tags
    end
    user
  end
end
```