### PR TITLE
Add with_transaction helper on CompositeCommand

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,29 @@
 PATH
   remote: .
   specs:
-    active_model_command (0.1.2)
-      activemodel (>= 2.2.0)
+    active_model_command (0.1.4)
+      activerecord (>= 2.2.0)
+      sqlite3 (~> 1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3)
-      activesupport (= 6.1.3)
-    activesupport (6.1.3)
+    activemodel (6.1.4)
+      activesupport (= 6.1.4)
+    activerecord (6.1.4)
+      activemodel (= 6.1.4)
+      activesupport (= 6.1.4)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.3)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -35,6 +39,7 @@ GEM
     rspec-support (3.9.3)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    sqlite3 (1.4.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     zeitwerk (2.4.2)

--- a/active_model_command.gemspec
+++ b/active_model_command.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
 
-  spec.add_runtime_dependency "activemodel", ">= 2.2.0"
+  spec.add_runtime_dependency "sqlite3", "~> 1.4"
+  spec.add_runtime_dependency "activerecord", ">= 2.2.0"
 end

--- a/lib/active_model/command.rb
+++ b/lib/active_model/command.rb
@@ -1,4 +1,4 @@
-require "active_model"
+require "active_record"
 require "active_model/command/version"
 
 module ActiveModel

--- a/lib/active_model/command/version.rb
+++ b/lib/active_model/command/version.rb
@@ -1,5 +1,5 @@
 module ActiveModel
   module Command
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end

--- a/lib/active_model/composite_command.rb
+++ b/lib/active_model/composite_command.rb
@@ -31,5 +31,16 @@ module ActiveModel
       return command.result if command.success?
       raise HaltedExecution.new(command)
     end
+
+    def with_transaction(&block)
+      ActiveRecord::Base.transaction do
+        begin
+          block.call
+        rescue HaltedExecution => e
+          handle_halted_execution(e)
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
   end
 end

--- a/spec/examples/with_transaction_composite_command.rb
+++ b/spec/examples/with_transaction_composite_command.rb
@@ -1,0 +1,20 @@
+class WithTransactionCompositeCommand
+  prepend ActiveModel::CompositeCommand
+  attr_reader :subcommands
+
+  validates :subcommands, presence: true
+
+  def initialize(subcommands)
+    @subcommands = subcommands
+  end
+
+  def call
+    with_transaction do
+      subcommands.each do |subcommand|
+        call_subcommand subcommand
+      end
+    end
+
+    :result
+  end
+end


### PR DESCRIPTION
Adds `with_transaction(&block)` helper se we can execute a given **block** inside an `ActiveRecord` transaction. In case we have any errors, an `ActiveRecord::Rollback` will be raised in order to avoid persisting any data.

The goal here is to stop duplicating this code on every custom command we have and just provide it as a helper.